### PR TITLE
minSdkVersion 26 -> 24

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 26
     defaultConfig {
         applicationId "com.cogwerks.potato"
-        minSdkVersion 26
+        minSdkVersion 24
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
I have problems running Android Studio's emulator on my laptop so I mainly test code on my own phone, which is API level 24. This PR just changes the `minSdkVersion` value in `build.gradle` from 26 to 24, so that I can run code easier. `compileSdkVersion` and `targetSdkVersion` are unchanged.
```
...
android {
    compileSdkVersion 26
    defaultConfig {
        applicationId "com.cogwerks.potato"
        minSdkVersion 24
        targetSdkVersion 26
        versionCode 1
        versionName "1.0"
        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
    } ...
```