### PR TITLE
detailed view layout + recyclerview item layout

### DIFF
--- a/app/src/main/java/com/cogwerks/potato/PotatoAdapter.java
+++ b/app/src/main/java/com/cogwerks/potato/PotatoAdapter.java
@@ -5,6 +5,7 @@ import android.support.v7.widget.RecyclerView.Adapter;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import java.util.ArrayList;
@@ -46,14 +47,20 @@ public class PotatoAdapter extends RecyclerView.Adapter<PotatoAdapter.PotatoView
 
     class PotatoViewHolder extends RecyclerView.ViewHolder {
         private TextView mResultTextView;
+        private TextView mResultConfidenceView;
+        private ProgressBar mResultPercentBar;
 
         public PotatoViewHolder(View itemView) {
             super(itemView);
             mResultTextView = (TextView) itemView.findViewById(R.id.tv_result_text);
+            mResultConfidenceView = (TextView) itemView.findViewById(R.id.tv_result_confidence);
+            mResultPercentBar = (ProgressBar) itemView.findViewById(R.id.tv_result_percent_bar);
         }
 
         public void bind(String result){
-            mResultTextView.setText(result);
+            mResultTextView.setText(result + ":");
+            mResultConfidenceView.setText("70%");
+            mResultPercentBar.setProgress(70);
         }
     }
 }

--- a/app/src/main/res/layout/activity_result_detail.xml
+++ b/app/src/main/res/layout/activity_result_detail.xml
@@ -4,11 +4,34 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.cogwerks.potato.ResultDetailActivity">
+    tools:context="com.cogwerks.potato.ResultDetailActivity"
+    android:orientation="vertical">
 
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/rv_result_list"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:gravity="left"
+        android:orientation="vertical"
+        android:padding="12dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Guesses: "
+            android:textSize="20sp"/>
+
+    </LinearLayout>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/rv_result_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </FrameLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/result_list_item.xml
+++ b/app/src/main/res/layout/result_list_item.xml
@@ -9,7 +9,32 @@
         android:id="@+id/tv_result_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="18dp"
-        android:textSize="32sp"/>
+        android:layout_weight="1"
+        android:layout_gravity="start"
+        android:layout_marginStart="32dp"
+        android:textSize="20sp"/>
 
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_gravity="end"
+        android:layout_marginEnd="32dp" >
+
+        <TextView
+            android:id="@+id/tv_result_confidence"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="20sp" />
+
+        <ProgressBar
+            android:id="@+id/tv_result_percent_bar"
+            style="@android:style/Widget.ProgressBar.Horizontal"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="8dp"
+            android:progress="0" />
+
+    </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
Fixes #3 

Enhanced layouts for detail-view and tag/confidence-items. There is dummy info in the adapter that hardcodes 70% as the confidence value for our current dummy tag. 

Should look something like this:
![29196312_765649630296671_8512447609544114176_o](https://user-images.githubusercontent.com/9158473/37388292-2450df3c-271d-11e8-8915-2b184825ed2d.png)
