### PR TITLE
POST gallery image in API Analyze Image call + display tags as items in RV

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:recyclerview-v7:26.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.squareup.okhttp3:okhttp:3.9.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'com.android.support:recyclerview-v7:26.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     implementation 'com.squareup.okhttp3:okhttp:3.9.1'
+    implementation 'org.apache.directory.studio:org.apache.commons.io:2.4'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.cogwerks.potato">
 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/cogwerks/potato/MainActivity.java
+++ b/app/src/main/java/com/cogwerks/potato/MainActivity.java
@@ -1,5 +1,6 @@
 package com.cogwerks.potato;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
@@ -19,7 +20,9 @@ import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 
 public class MainActivity extends AppCompatActivity {
@@ -28,6 +31,7 @@ public class MainActivity extends AppCompatActivity {
     private ImageView mUserPic;
     private ImageButton mChooseGallery;
     private ImageButton mChooseCamera;
+    private String mImageFileName = "imageFile";
     private int PICK_IMAGE_REQUEST = 1;
     private static final String IMAGE_TYPE = "image/*";
     private static final String TAG = MainActivity.class.getSimpleName();
@@ -95,7 +99,13 @@ public class MainActivity extends AppCompatActivity {
                 Bitmap bitmap = MediaStore.Images.Media.getBitmap(getContentResolver(), uri);
                 ImageView imageView = (ImageView) findViewById(R.id.iv_user_image);
                 imageView.setImageBitmap(bitmap);
-                //send this data to our api
+
+                // prepare our acquired image data for our api... by saving to a local file first
+                ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, bytes);
+                FileOutputStream fos = openFileOutput(mImageFileName, Context.MODE_PRIVATE);
+                fos.write(bytes.toByteArray());
+                fos.close();
             } catch (IOException e) {
                 Log.d("Error: ", "Failed to receive image. Please try again");
             }

--- a/app/src/main/java/com/cogwerks/potato/MainActivity.java
+++ b/app/src/main/java/com/cogwerks/potato/MainActivity.java
@@ -22,7 +22,7 @@ import android.widget.TextView;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-public class MainActivity extends AppCompatActivity implements LoaderManager.LoaderCallbacks<String> {
+public class MainActivity extends AppCompatActivity {
 
     private EditText mPotatoSearchText;
     private ImageView mUserPic;
@@ -100,32 +100,5 @@ public class MainActivity extends AppCompatActivity implements LoaderManager.Loa
                 Log.d("Error: ", "Failed to receive image. Please try again");
             }
         }
-    }
-
-    @Override
-    public Loader<String> onCreateLoader(int id, Bundle args) {
-        String potatoURL = null;
-        if(args != null){
-            potatoURL = args.getString("potatoURL");
-        }
-        return new PotatoLoader(this, potatoURL);
-    }
-
-    @Override
-    public void onLoadFinished(Loader<String> loader, String data) {
-        Log.d(TAG, "Got result from loader");
-        if (data != null){
-            mLoadingErrorMessageTV.setVisibility(View.INVISIBLE);
-        }
-        else{
-            mLoadingErrorMessageTV.setVisibility(View.VISIBLE);
-        }
-
-    }
-
-
-    @Override
-    public void onLoaderReset(Loader loader) {
-
     }
 }

--- a/app/src/main/java/com/cogwerks/potato/PotatoAdapter.java
+++ b/app/src/main/java/com/cogwerks/potato/PotatoAdapter.java
@@ -33,7 +33,7 @@ public class PotatoAdapter extends RecyclerView.Adapter<PotatoAdapter.PotatoView
 
     @Override
     public void onBindViewHolder(PotatoViewHolder holder, int position) {
-        MSAzureComputerVisionUtils.AnalyzeResult result = mResultList.get(mResultList.size() - position - 1);
+        MSAzureComputerVisionUtils.AnalyzeResult result = mResultList.get(position);
         holder.bind(result);
     }
 
@@ -61,8 +61,8 @@ public class PotatoAdapter extends RecyclerView.Adapter<PotatoAdapter.PotatoView
 
         public void bind(MSAzureComputerVisionUtils.AnalyzeResult result){
             mResultTextView.setText(result.tag + ":");
-            mResultConfidenceView.setText("70%");
-            mResultPercentBar.setProgress(70);
+            mResultConfidenceView.setText(Integer.toString(result.roundConfidence()) + "%");
+            mResultPercentBar.setProgress(result.roundConfidence());
         }
     }
 }

--- a/app/src/main/java/com/cogwerks/potato/PotatoAdapter.java
+++ b/app/src/main/java/com/cogwerks/potato/PotatoAdapter.java
@@ -8,6 +8,8 @@ import android.view.ViewGroup;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import com.cogwerks.potato.utils.MSAzureComputerVisionUtils;
+
 import java.util.ArrayList;
 
 /**
@@ -15,10 +17,10 @@ import java.util.ArrayList;
  */
 
 public class PotatoAdapter extends RecyclerView.Adapter<PotatoAdapter.PotatoViewHolder> {
-    private ArrayList<String> mResultList;
+    private ArrayList<MSAzureComputerVisionUtils.AnalyzeResult> mResultList;
 
     public PotatoAdapter(){
-        mResultList = new ArrayList<String>();
+        mResultList = new ArrayList<MSAzureComputerVisionUtils.AnalyzeResult>();
     }
 
     @Override
@@ -31,12 +33,12 @@ public class PotatoAdapter extends RecyclerView.Adapter<PotatoAdapter.PotatoView
 
     @Override
     public void onBindViewHolder(PotatoViewHolder holder, int position) {
-        String result = mResultList.get(mResultList.size() - position - 1);
+        MSAzureComputerVisionUtils.AnalyzeResult result = mResultList.get(mResultList.size() - position - 1);
         holder.bind(result);
     }
 
-    public void addResult(String result){
-        mResultList.add(result);
+    public void updateResults(ArrayList<MSAzureComputerVisionUtils.AnalyzeResult> results) {
+        mResultList = results;
         notifyDataSetChanged();
     }
 
@@ -57,8 +59,8 @@ public class PotatoAdapter extends RecyclerView.Adapter<PotatoAdapter.PotatoView
             mResultPercentBar = (ProgressBar) itemView.findViewById(R.id.tv_result_percent_bar);
         }
 
-        public void bind(String result){
-            mResultTextView.setText(result + ":");
+        public void bind(MSAzureComputerVisionUtils.AnalyzeResult result){
+            mResultTextView.setText(result.tag + ":");
             mResultConfidenceView.setText("70%");
             mResultPercentBar.setProgress(70);
         }

--- a/app/src/main/java/com/cogwerks/potato/PotatoLoader.java
+++ b/app/src/main/java/com/cogwerks/potato/PotatoLoader.java
@@ -6,6 +6,8 @@ import android.support.v4.content.AsyncTaskLoader;
 import android.util.Log;
 
 
+import com.cogwerks.potato.utils.NetworkUtils;
+
 import java.io.IOException;
 import java.security.acl.LastOwnerException;
 
@@ -40,14 +42,14 @@ public class PotatoLoader extends AsyncTaskLoader<String> {
     @Override
     public String loadInBackground() {
         if(mPotatoURL != null){
-            Log.d(TAG, "Loading reults from API");
+            Log.d(TAG, "Loading results from API with URL: " + mPotatoURL);
             String potatoResults = null;
-            /*try{
-                /*potatoResults = get the results from the api;*
-            }
-            catch(IOException e){
+            try {
+                potatoResults = NetworkUtils.doHTTPPost(mPotatoURL); // doHTTPPost should perform the analyze call on a static web image.
+            } catch (IOException e) {
                 e.printStackTrace();
-            }*/
+            }
+            Log.d(TAG, "loadInBackground: " + potatoResults);
             return potatoResults;
         }
         else{

--- a/app/src/main/java/com/cogwerks/potato/PotatoLoader.java
+++ b/app/src/main/java/com/cogwerks/potato/PotatoLoader.java
@@ -18,22 +18,30 @@ import java.security.acl.LastOwnerException;
 public class PotatoLoader extends AsyncTaskLoader<String> {
     String mPotatoResultsJSON;
     String mPotatoURL;
+    byte[] mPotatoBytes; // delicious
 
     private static final String TAG = MainActivity.class.getSimpleName();
 
-    PotatoLoader(Context context, String url){
+    PotatoLoader(Context context, String url, byte[] data){
         super(context);
         mPotatoURL = url;
+        mPotatoBytes = data;
     }
 
     @Override
     protected void onStartLoading(){
+        Log.d(TAG, "Inside onStartLoading.");
+        if (mPotatoBytes != null) {
+            Log.d(TAG, "onStartLoading: mPotatoBytes != null");
+        }
         if(mPotatoURL != null){
-            if(mPotatoResultsJSON != null){
-                Log.d(TAG, "Loader returns cached results");
+            Log.d(TAG, "onStartLoading: mPotatoURL != null");
+            if(mPotatoResultsJSON != null){ // apparently this can sometimes be null while bytes and url are not?
+                Log.d(TAG, "onStartLoading: mPotatoResultsJSON != null. Loader ret cached results");
                 deliverResult(mPotatoResultsJSON);
             }
             else{
+                Log.d(TAG, "onStartLoading: force loading.");
                 forceLoad();
             }
         }
@@ -41,11 +49,11 @@ public class PotatoLoader extends AsyncTaskLoader<String> {
 
     @Override
     public String loadInBackground() {
-        if(mPotatoURL != null){
+        if(mPotatoURL != null && mPotatoBytes != null){
             Log.d(TAG, "Loading results from API with URL: " + mPotatoURL);
             String potatoResults = null;
             try {
-                potatoResults = NetworkUtils.doHTTPPost(mPotatoURL); // doHTTPPost should perform the analyze call on a static web image.
+                potatoResults = NetworkUtils.doHTTPPost(mPotatoURL, mPotatoBytes);
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/app/src/main/java/com/cogwerks/potato/ResultDetailActivity.java
+++ b/app/src/main/java/com/cogwerks/potato/ResultDetailActivity.java
@@ -5,8 +5,13 @@ import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+
+import com.cogwerks.potato.utils.MSAzureComputerVisionUtils;
 
 public class ResultDetailActivity extends AppCompatActivity {
+    private static final String TAG = ResultDetailActivity.class.getSimpleName();
+
     private RecyclerView mResultListRecyclerView;
     private PotatoAdapter mPotatoAdapter;
 
@@ -29,5 +34,11 @@ public class ResultDetailActivity extends AppCompatActivity {
             String searchString = intent.getExtras().getString("searchString");
             mPotatoAdapter.addResult(searchString);
         }
+        loadResults();
+    }
+
+    public void loadResults() {
+        String url = MSAzureComputerVisionUtils.buildAnalyzeURL();
+        Log.d(TAG, "loadResults: " + url);
     }
 }

--- a/app/src/main/java/com/cogwerks/potato/ResultDetailActivity.java
+++ b/app/src/main/java/com/cogwerks/potato/ResultDetailActivity.java
@@ -9,10 +9,13 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 
+import com.cogwerks.potato.utils.MSAzureComputerVisionUtils;
+
 public class ResultDetailActivity extends AppCompatActivity implements LoaderManager.LoaderCallbacks<String> {
     private static final String TAG = ResultDetailActivity.class.getSimpleName();
 
     private static final String ANALYZE_URL_KEY = "visionAnalyzeURL";
+    private static final int VISION_ANALYZE_LOADER_ID = 0;
 
     private RecyclerView mResultListRecyclerView;
     private PotatoAdapter mPotatoAdapter;
@@ -36,6 +39,15 @@ public class ResultDetailActivity extends AppCompatActivity implements LoaderMan
             String searchString = intent.getExtras().getString("searchString");
             mPotatoAdapter.addResult(searchString);
         }
+
+        getSupportLoaderManager().initLoader(VISION_ANALYZE_LOADER_ID, null, this);
+    }
+
+    private void doVisionAnalyze() {
+        String visionAnalyzeURL = MSAzureComputerVisionUtils.buildAnalyzeURL();
+        Bundle args = new Bundle();
+        args.putString(ANALYZE_URL_KEY, visionAnalyzeURL);
+        getSupportLoaderManager().restartLoader(VISION_ANALYZE_LOADER_ID, args, this);
     }
 
     @Override

--- a/app/src/main/java/com/cogwerks/potato/ResultDetailActivity.java
+++ b/app/src/main/java/com/cogwerks/potato/ResultDetailActivity.java
@@ -14,6 +14,7 @@ import android.util.Log;
 import com.cogwerks.potato.utils.MSAzureComputerVisionUtils;
 
 import java.io.FileNotFoundException;
+import java.util.ArrayList;
 
 public class ResultDetailActivity extends AppCompatActivity implements LoaderManager.LoaderCallbacks<String> {
     private static final String TAG = ResultDetailActivity.class.getSimpleName();
@@ -41,7 +42,6 @@ public class ResultDetailActivity extends AppCompatActivity implements LoaderMan
         Intent intent = getIntent();
         if(intent != null && intent.hasExtra("searchString")){
             String searchString = intent.getExtras().getString("searchString");
-            mPotatoAdapter.addResult(searchString);
         }
 
         // retrieve our saved image here, and call doVisionAnalyze... perhaps edit to take file.
@@ -76,8 +76,9 @@ public class ResultDetailActivity extends AppCompatActivity implements LoaderMan
         Log.d(TAG, "onLoadFinished: got results from loader");
         if (data != null) {
             // declare ArrayList of custom-class instances that represents list of grabbed tags. Assign parse results of "data" to it.
+            ArrayList<MSAzureComputerVisionUtils.AnalyzeResult> tags = MSAzureComputerVisionUtils.parseAnalyzeResultsJSON(data);
             // Through the adapter, update the results with the above ArrayList
-            mPotatoAdapter.addResult(data);
+            mPotatoAdapter.updateResults(tags);
         } else {
             // set loading error to be visible (see MainActivity version for ref)
         }

--- a/app/src/main/java/com/cogwerks/potato/ResultDetailActivity.java
+++ b/app/src/main/java/com/cogwerks/potato/ResultDetailActivity.java
@@ -1,6 +1,8 @@
 package com.cogwerks.potato;
 
 import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.content.Loader;
 import android.support.v7.app.AppCompatActivity;
@@ -10,6 +12,8 @@ import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 
 import com.cogwerks.potato.utils.MSAzureComputerVisionUtils;
+
+import java.io.FileNotFoundException;
 
 public class ResultDetailActivity extends AppCompatActivity implements LoaderManager.LoaderCallbacks<String> {
     private static final String TAG = ResultDetailActivity.class.getSimpleName();
@@ -40,6 +44,13 @@ public class ResultDetailActivity extends AppCompatActivity implements LoaderMan
             mPotatoAdapter.addResult(searchString);
         }
 
+        // retrieve our saved image here, and call doVisionAnalyze... perhaps edit to take file.
+        try {
+            Bitmap bitmap = BitmapFactory.decodeStream(this.getApplicationContext().openFileInput("imageFile"));
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        doVisionAnalyze();
         getSupportLoaderManager().initLoader(VISION_ANALYZE_LOADER_ID, null, this);
     }
 

--- a/app/src/main/java/com/cogwerks/potato/ResultDetailActivity.java
+++ b/app/src/main/java/com/cogwerks/potato/ResultDetailActivity.java
@@ -1,16 +1,18 @@
 package com.cogwerks.potato;
 
 import android.content.Intent;
+import android.support.v4.app.LoaderManager;
+import android.support.v4.content.Loader;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
 
-import com.cogwerks.potato.utils.MSAzureComputerVisionUtils;
-
-public class ResultDetailActivity extends AppCompatActivity {
+public class ResultDetailActivity extends AppCompatActivity implements LoaderManager.LoaderCallbacks<String> {
     private static final String TAG = ResultDetailActivity.class.getSimpleName();
+
+    private static final String ANALYZE_URL_KEY = "visionAnalyzeURL";
 
     private RecyclerView mResultListRecyclerView;
     private PotatoAdapter mPotatoAdapter;
@@ -34,11 +36,32 @@ public class ResultDetailActivity extends AppCompatActivity {
             String searchString = intent.getExtras().getString("searchString");
             mPotatoAdapter.addResult(searchString);
         }
-        loadResults();
     }
 
-    public void loadResults() {
-        String url = MSAzureComputerVisionUtils.buildAnalyzeURL();
-        Log.d(TAG, "loadResults: " + url);
+    @Override
+    public Loader<String> onCreateLoader(int id, Bundle args) {
+        Log.d(TAG, "onCreateLoader being called");
+        String visionAnalyzeURL = null;
+        if (args != null) {
+            visionAnalyzeURL = args.getString(ANALYZE_URL_KEY);
+        }
+        return new PotatoLoader(this, visionAnalyzeURL);
+    }
+
+    @Override
+    public void onLoadFinished(Loader<String> loader, String data) {
+        Log.d(TAG, "onLoadFinished: got results from loader");
+        if (data != null) {
+            // declare ArrayList of custom-class instances that represents list of grabbed tags. Assign parse results of "data" to it.
+            // Through the adapter, update the results with the above ArrayList
+            mPotatoAdapter.addResult(data);
+        } else {
+            // set loading error to be visible (see MainActivity version for ref)
+        }
+    }
+
+    @Override
+    public void onLoaderReset(Loader<String> loader) {
+        // Nothing to do
     }
 }

--- a/app/src/main/java/com/cogwerks/potato/utils/MSAzureComputerVisionUtils.java
+++ b/app/src/main/java/com/cogwerks/potato/utils/MSAzureComputerVisionUtils.java
@@ -1,0 +1,29 @@
+package com.cogwerks.potato.utils;
+
+import android.net.Uri;
+
+/**
+ * Created by annie on 3/17/18.
+ */
+
+public class MSAzureComputerVisionUtils {
+    private final static String CV_ANALYZE_BASE_URL = "https://westcentralus.api.cognitive.microsoft.com/vision/v1.0/analyze";
+
+    private final static String CV_ANALYZE_FEATURES_PARAM = "visualFeatures";
+    private final static String CV_ANALYZE_FEATURES_VALUE = "Description,Tags,Color,Faces,Adult";
+
+    private final static String CV_ANALYZE_DETAILS_PARAM = "details";
+    private final static String CV_ANALYZE_DETAILS_VALUE = "Celebrities,Landmarks";
+
+    private final static String CV_ANALYZE_API_KEY_PARAM = "subscription-key";
+    private final static String CV_ANALYZE_API_KEY_VALUE = "placeholder";
+
+    public static String buildAnalyzeURL() {
+        return Uri.parse(CV_ANALYZE_BASE_URL).buildUpon()
+                .appendQueryParameter(CV_ANALYZE_FEATURES_PARAM, CV_ANALYZE_FEATURES_VALUE)
+                .appendQueryParameter(CV_ANALYZE_DETAILS_PARAM, CV_ANALYZE_DETAILS_VALUE)
+                .appendQueryParameter(CV_ANALYZE_API_KEY_PARAM, CV_ANALYZE_API_KEY_VALUE)
+                .build()
+                .toString();
+    }
+}

--- a/app/src/main/java/com/cogwerks/potato/utils/MSAzureComputerVisionUtils.java
+++ b/app/src/main/java/com/cogwerks/potato/utils/MSAzureComputerVisionUtils.java
@@ -7,6 +7,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 
 /**
@@ -28,6 +30,17 @@ public class MSAzureComputerVisionUtils {
     public static class AnalyzeResult implements Serializable {
         public String tag;
         public String confidence;
+
+        /* Converts confidence from string to double, then rounds to two decimal places and
+        multiples by 100 to return a percentage
+        */
+        public int roundConfidence() {
+            double confidenceDec = Double.parseDouble(this.confidence);
+            BigDecimal bd = new BigDecimal(confidenceDec);
+            bd = bd.setScale(2, RoundingMode.HALF_UP);
+            double percent = bd.doubleValue() * 100;
+            return (int)percent;
+        }
     }
 
     public static String buildAnalyzeURL() {

--- a/app/src/main/java/com/cogwerks/potato/utils/MSAzureComputerVisionUtils.java
+++ b/app/src/main/java/com/cogwerks/potato/utils/MSAzureComputerVisionUtils.java
@@ -10,13 +10,13 @@ public class MSAzureComputerVisionUtils {
     private final static String CV_ANALYZE_BASE_URL = "https://westcentralus.api.cognitive.microsoft.com/vision/v1.0/analyze";
 
     private final static String CV_ANALYZE_FEATURES_PARAM = "visualFeatures";
-    private final static String CV_ANALYZE_FEATURES_VALUE = "Description,Tags,Color,Faces,Adult";
+    private final static String CV_ANALYZE_FEATURES_VALUE = "Tags";
 
     private final static String CV_ANALYZE_DETAILS_PARAM = "details";
-    private final static String CV_ANALYZE_DETAILS_VALUE = "Celebrities,Landmarks";
+    private final static String CV_ANALYZE_DETAILS_VALUE = "Celebrities";
 
     private final static String CV_ANALYZE_API_KEY_PARAM = "subscription-key";
-    private final static String CV_ANALYZE_API_KEY_VALUE = "placeholder";
+    private final static String CV_ANALYZE_API_KEY_VALUE = "a97aab14e3264b74a601e0c38cfcd9bc";
 
     public static String buildAnalyzeURL() {
         return Uri.parse(CV_ANALYZE_BASE_URL).buildUpon()

--- a/app/src/main/java/com/cogwerks/potato/utils/MSAzureComputerVisionUtils.java
+++ b/app/src/main/java/com/cogwerks/potato/utils/MSAzureComputerVisionUtils.java
@@ -2,6 +2,13 @@ package com.cogwerks.potato.utils;
 
 import android.net.Uri;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
 /**
  * Created by annie on 3/17/18.
  */
@@ -10,13 +17,18 @@ public class MSAzureComputerVisionUtils {
     private final static String CV_ANALYZE_BASE_URL = "https://westcentralus.api.cognitive.microsoft.com/vision/v1.0/analyze";
 
     private final static String CV_ANALYZE_FEATURES_PARAM = "visualFeatures";
-    private final static String CV_ANALYZE_FEATURES_VALUE = "Tags";
+    private final static String CV_ANALYZE_FEATURES_VALUE = "Tags,Description,Color,Faces,Adult";
 
     private final static String CV_ANALYZE_DETAILS_PARAM = "details";
-    private final static String CV_ANALYZE_DETAILS_VALUE = "Celebrities";
+    private final static String CV_ANALYZE_DETAILS_VALUE = "Celebrities,Landmarks";
 
     private final static String CV_ANALYZE_API_KEY_PARAM = "subscription-key";
     private final static String CV_ANALYZE_API_KEY_VALUE = "a97aab14e3264b74a601e0c38cfcd9bc";
+
+    public static class AnalyzeResult implements Serializable {
+        public String tag;
+        public String confidence;
+    }
 
     public static String buildAnalyzeURL() {
         return Uri.parse(CV_ANALYZE_BASE_URL).buildUpon()
@@ -25,5 +37,24 @@ public class MSAzureComputerVisionUtils {
                 .appendQueryParameter(CV_ANALYZE_API_KEY_PARAM, CV_ANALYZE_API_KEY_VALUE)
                 .build()
                 .toString();
+    }
+
+    public static ArrayList<AnalyzeResult> parseAnalyzeResultsJSON(String resultsJSON) {
+        try {
+            JSONObject resultsObj = new JSONObject(resultsJSON); // grab entire string as JSON object
+            JSONArray resultsItems  = resultsObj.getJSONArray("tags"); // grab tags array
+
+            ArrayList<AnalyzeResult> analyzeResultsList = new ArrayList<AnalyzeResult>();
+            for (int i = 0; i < resultsItems.length(); i++) { // for each key/val object in tags,
+                AnalyzeResult result = new AnalyzeResult();
+                JSONObject resultItem = resultsItems.getJSONObject(i); // grab {tag_name: confidence} object
+                result.tag = resultItem.getString("name");
+                result.confidence = resultItem.getString("confidence");
+                analyzeResultsList.add(result);
+            }
+            return analyzeResultsList;
+        } catch (JSONException e) {
+            return  null;
+        }
     }
 }

--- a/app/src/main/java/com/cogwerks/potato/utils/NetworkUtils.java
+++ b/app/src/main/java/com/cogwerks/potato/utils/NetworkUtils.java
@@ -1,21 +1,41 @@
 package com.cogwerks.potato.utils;
 
+import java.io.IOException;
+
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okhttp3.Response;
-
-import java.io.IOException;
 
 /**
  * Created by annie on 3/17/18.
  */
 
 public class NetworkUtils {
+    private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+    private static final MediaType BINARY = MediaType.parse("application/octet-stream; charset=binary");
+
     private static final OkHttpClient mHTTPClient = new OkHttpClient();
 
     public static String doHTTPGet(String url) throws IOException {
         Request request = new Request.Builder()
                 .url(url)
+                .build();
+        Response response = mHTTPClient.newCall(request).execute();
+
+        try {
+            return response.body().string();
+        } finally {
+            response.close();
+        }
+    }
+
+    public static String doHTTPPost(String url) throws IOException {
+        RequestBody body = RequestBody.create(JSON, "{\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/Broadway_and_Times_Square_by_night.jpg\"}");
+        Request request = new Request.Builder()
+                .url(url)
+                .post(body)
                 .build();
         Response response = mHTTPClient.newCall(request).execute();
 

--- a/app/src/main/java/com/cogwerks/potato/utils/NetworkUtils.java
+++ b/app/src/main/java/com/cogwerks/potato/utils/NetworkUtils.java
@@ -1,6 +1,14 @@
 package com.cogwerks.potato.utils;
 
+import android.content.Context;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -31,8 +39,9 @@ public class NetworkUtils {
         }
     }
 
-    public static String doHTTPPost(String url) throws IOException {
-        RequestBody body = RequestBody.create(JSON, "{\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/Broadway_and_Times_Square_by_night.jpg\"}");
+    public static String doHTTPPost(String url, byte[] data) throws IOException {
+        // RequestBody body = RequestBody.create(JSON, "{\"url\":\"https://upload.wikimedia.org/wikipedia/commons/1/12/Broadway_and_Times_Square_by_night.jpg\"}");
+        RequestBody body = RequestBody.create(BINARY, data);
         Request request = new Request.Builder()
                 .url(url)
                 .post(body)

--- a/app/src/main/java/com/cogwerks/potato/utils/NetworkUtils.java
+++ b/app/src/main/java/com/cogwerks/potato/utils/NetworkUtils.java
@@ -1,0 +1,28 @@
+package com.cogwerks.potato.utils;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+
+/**
+ * Created by annie on 3/17/18.
+ */
+
+public class NetworkUtils {
+    private static final OkHttpClient mHTTPClient = new OkHttpClient();
+
+    public static String doHTTPGet(String url) throws IOException {
+        Request request = new Request.Builder()
+                .url(url)
+                .build();
+        Response response = mHTTPClient.newCall(request).execute();
+
+        try {
+            return response.body().string();
+        } finally {
+            response.close();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5 #8 

## So far
- [X] Can successfully make calls to API
- [X] Can successfully stick response information ^^^ in the recycler view
- [x] Parse response information such that each tag and corresponding confidence is appropriately displayed per recycler view item
- [x] Replace current test image (web url) with actual user image for POST

## TODO 
- [ ] Parse response information such that non-tag stuff is also displayed in the detail view
- [ ] Add loading bar or something?? -> can be addressed in separate PR

## To test
- upload image via gallery button. Results might take a while to load; stare at logcat output to ease your boredom. 

## Things to consider while reviewing
- I... don't really know what I'm doing with lifecycle stuff and I think atm results aren't getting cached properly (try watching the console output and rotating the phone). A major change I did was nuking the loader stuff off the main activity and doing loader stuff for the `ResultDetailActivity` instead, since the adapter for the recycler lives there. Does this make sense? The way I ended up implementing this, it may also be possible to have loader stuff happen in the main activity and pass relevant image and url data to the `ResultDetailActivity` via intents.

## Current output:
![screenshot_20180319-055023](https://user-images.githubusercontent.com/9158473/37596927-fe9497c6-2b3a-11e8-906a-566de748e5ca.png)
